### PR TITLE
Made logout dropdown align on the right side of navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -71,7 +71,7 @@ export const Navbar = () => {
                         <AvatarFallback>{user?.username[0].toUpperCase() ?? ""}</AvatarFallback>
                       </Avatar>
                     </ProfileMenubarTrigger>
-                    <ProfileMenubarContent>
+                    <ProfileMenubarContent align="end">
                       {/* <ProfileMenubarItem className="cursor-pointer" onClick={() => {
                         setTheme(theme === "light" ? "dark" : "light");
                       }}><Sun className="dark:block hidden h-4 w-4 mr-2" /><Moon className="dark:hidden block h-4 w-4 mr-2" /> Toggle Appearance</ProfileMenubarItem>


### PR DESCRIPTION
This pull request includes a small change to the `components/navbar.tsx` file. The change aligns the `ProfileMenubarContent` to the end.

* [`components/navbar.tsx`](diffhunk://#diff-697415f51799297bd64388e550f60789de985cb60aca6be2175bc512c9243626L74-R74): Modified the `ProfileMenubarContent` component to include an `align="end"` attribute.