### PR TITLE
[Improvement] Changed Levels Per Game from 2 to 5

### DIFF
--- a/app/(gameplay)/game/_context/GameContext.tsx
+++ b/app/(gameplay)/game/_context/GameContext.tsx
@@ -60,7 +60,7 @@ export const GameProvider = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [allScores, setAllScores] = useState<number[]>([]);
 
-  const levelIds = useQuery(api.game.getRandomLevels, { cacheBuster, numOfLevels: 2n });
+  const levelIds = useQuery(api.game.getRandomLevels, { cacheBuster, numOfLevels: 5n }); // ! Update this number to change number of levels pulled per game
   const imageSrcs = useQuery(api.game.getImageSrcs, currentLevelId ? { levelId: currentLevelId } : "skip");
   const imageIds = useQuery(api.game.getImageIds, currentLevelId ? { levelId: currentLevelId } : "skip");
   const checkGuess = useMutation(api.game.checkGuess);


### PR DESCRIPTION
This pull request includes a small but significant change to the `GameContext.tsx` file. The number of levels pulled per game has been increased from 2 to 5 to account for new levels being added to the backend db.

* [`app/(gameplay)/game/_context/GameContext.tsx`](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dL63-R63): Updated the `numOfLevels` parameter in the `useQuery` call for `getRandomLevels` to 5.