### PR TITLE
[Improvement] Version Number Shown in Footer Now Gets Dynamically Pulled From GitHub

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,12 +1,10 @@
 import Link from "next/link";
 import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
-import { GitBranch, Github, Mail } from "lucide-react";
-import packageJson from '../package.json';
+import { Github, Mail } from "lucide-react";
+import VersionButton from "./version-button";
 
 export const Footer = () => {
-  const { version } = packageJson;
-
   return (
     <div className="flex items-center justify-between w-full p-6 bg-transparent z-5">
       <DropdownMenu>
@@ -39,11 +37,7 @@ export const Footer = () => {
             <Github className="text-muted-foreground w-5 h-5" />
           </Button>
         </Link>
-        <Link href="https://github.com/DylanDevelops/aidentify/releases" target="_blank">
-          <Button variant="ghost" className="text-muted-foreground">
-            <GitBranch className="w-5 h-5 mr-2" /> v{version}
-          </Button>
-        </Link>
+        <VersionButton />
       </div>
     </div>
   );

--- a/components/version-button.tsx
+++ b/components/version-button.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "./ui/button";
+import { GitBranch } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Skeleton } from "./ui/skeleton";
+
+const VersionButton = () => {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchVersion() {
+      const response = await fetch('https://api.github.com/repos/dylandevelops/aidentify/releases');
+      const releases = await response.json();
+      
+      if (releases.length > 0) {
+        const latestRelease = releases[0];
+        setVersion(latestRelease.name);
+      } else {
+        setVersion(null);
+      }
+    }
+
+    fetchVersion();
+  }, []);
+
+  if(!version) {
+    return (
+      <Link href="https://github.com/DylanDevelops/aidentify/releases" target="_blank">
+        <Button variant="ghost" className="text-muted-foreground">
+          <Skeleton className="h-5 w-28" />
+        </Button>
+      </Link>
+    );
+  }
+
+  return ( 
+    <Link href="https://github.com/DylanDevelops/aidentify/releases" target="_blank">
+      <Button variant="ghost" className="text-muted-foreground">
+        <GitBranch className="w-5 h-5 mr-2" /> {version}
+      </Button>
+    </Link>
+  );
+};
+ 
+export default VersionButton;


### PR DESCRIPTION
This pull request refactors the `Footer` component to improve maintainability and user experience by creating a new `VersionButton` component that dynamically fetches the latest release version from GitHub. The most important changes include the removal of the static version import, the addition of the `VersionButton` component, and the dynamic fetching of the version.

This removes the need to manually set the version number everytime that we have a release.

Refactoring and improvements:

* [`components/footer.tsx`](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L4-L9): Removed the static import of the version from `package.json` and replaced the version display with the new `VersionButton` component. [[1]](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L4-L9) [[2]](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L42-R40)
* [`components/version-button.tsx`](diffhunk://#diff-e8791d24a756ee4c7a7171c5427d9411f44e72b8b3020939ed41b39c188e9360R1-R47): Added a new `VersionButton` component that uses the `useEffect` hook to fetch the latest release version from the GitHub API and display it dynamically. If the version is not available, a skeleton loader is shown.