### PR TITLE
[fix] Updated Footer Year from 2024 to 2025

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,7 +10,7 @@ export const Footer = () => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="link">
-            <p className="text-sm text-muted-foreground">© 2024 • AIdentify</p>
+            <p className="text-sm text-muted-foreground">© 2025 • AIdentify</p>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">


### PR DESCRIPTION
This pull request includes a small change to the `components/footer.tsx` file. The change updates the copyright year.

* [`components/footer.tsx`](diffhunk://#diff-bd3f659ee78d8c923c9975bdb8842b2a346ff04023e42fe215c0d080ef5cf115L13-R13): Updated the copyright year from 2024 to 2025.

We don't want to merge this until the new year. I just set up this PR to be ready to go.