### PR TITLE
[added] Points System

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,7 +1,7 @@
 const config = {
   providers: [
     {
-      domain: "https://clerk.playaidentify.com",
+      domain: process.env.CLERK_DOMAIN,
       applicationID: "convex",
     },
   ]};

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -8,7 +8,7 @@ export default defineSchema({
     username: v.string(),
     emails: v.array(v.string()),
     level: v.int64(),
-    currentXP: v.int64(),
+    points: v.int64(),
     picture: v.string(),
     currentStreak: v.int64(),
     lastParticipationDate: v.string(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -48,7 +48,7 @@ export const upsertFromClerk = internalMutation({
         username: data.username!,
         emails: data.email_addresses ? data.email_addresses.map(email => email.email_address) : [],
         level: 1n,
-        currentXP: 0n,
+        points: 0n,
         picture: data.image_url,
         currentStreak: 0n,
         lastParticipationDate: new Date().toISOString(),


### PR DESCRIPTION
This pull request introduces several changes to the `GameContext` and related files to enhance user handling and game functionality. The most significant changes include integrating Clerk for user management, adding a mutation to finish the game, and updating the schema to use `points` instead of `currentXP`.

### User Management Enhancements:
* [`app/(gameplay)/game/_context/GameContext.tsx`](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR3): Integrated Clerk for user management by importing `useUser` and fetching the user data using `useQuery`. [[1]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR3) [[2]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR42-R44)

### Game Functionality Improvements:
* [`app/(gameplay)/game/_context/GameContext.tsx`](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR74): Added a new mutation `finishGame` to handle the end of the game, updating the score and routing to the results page. [[1]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR74) [[2]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dL131-R146)
* [`convex/game.ts`](diffhunk://#diff-7c7ea5f1500d5246076590330308c9cb9f007194904ee1ae1717c0380fb4a21cR168-R224): Added detailed documentation and implementation for the `finishGame` mutation, which updates user points and handles various scenarios based on the presence of a user ID.

### Configuration and Schema Updates:
* [`convex/auth.config.ts`](diffhunk://#diff-92df842200c44afba46258b9eed289495465de316bda3aa61b82f42331e30d6eL4-R4): Updated the Clerk domain to use an environment variable for better configuration management.
* [`convex/schema.ts`](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1L11-R11): Replaced `currentXP` with `points` in the user schema to reflect the new points system.
* [`convex/users.ts`](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L51-R51): Updated the `upsertFromClerk` mutation to initialize the `points` field instead of `currentXP`.