### PR TITLE
[fix] Empty hints are now filtered out

### DIFF
--- a/convex/levelUpload.ts
+++ b/convex/levelUpload.ts
@@ -63,11 +63,12 @@ export const createLevelWithImageIds = mutation({
   },
 
   handler: async (ctx, args) => {
+    const filteredHints = args.hints.filter((hint) => hint.trim() !== "");
     return await ctx.db.insert("levels", {
       images: [args.aiImageId, args.normalImageId],
       groupName: args.groupName,
       classification: args.classification,
-      hints: args.hints,
+      hints: filteredHints,
       totalPlays: 0n,
       correctAnswers: 0n,
     });


### PR DESCRIPTION
This pull request includes an improvement to the `createLevelWithImageIds` mutation in the `convex/levelUpload.ts` file. The change ensures that any empty hints are filtered out before being inserted into the database.

* [`convex/levelUpload.ts`](diffhunk://#diff-10bb17b00f17f544c308009d229f2a6acbc0e4646678cc83b8d1c2ff181b44b1R66-R71): Added a filter to remove empty hints from the `args.hints` array before inserting the level data into the database.