### PR TITLE
[fix] Removed redundant save and cancel buttons on user settings profile modal

### DIFF
--- a/app/(authentication)/layout.tsx
+++ b/app/(authentication)/layout.tsx
@@ -1,5 +1,5 @@
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { Loader2 } from "lucide-react";
 import { Suspense } from "react";
 

--- a/app/(developer)/layout.tsx
+++ b/app/(developer)/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { useAdminCheck } from "@/hooks/use-admin-check";
 import { useConvexAuth } from "convex/react";
 import { Loader2 } from "lucide-react";

--- a/app/(gameplay)/layout.tsx
+++ b/app/(gameplay)/layout.tsx
@@ -1,5 +1,5 @@
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { Loader2 } from "lucide-react";
 import { Suspense } from "react";
 

--- a/app/(legal)/layout.tsx
+++ b/app/(legal)/layout.tsx
@@ -1,5 +1,5 @@
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { Loader2 } from "lucide-react";
 import { Suspense } from "react";
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,5 +1,5 @@
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { Loader2 } from "lucide-react";
 import { Suspense } from "react";
 

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -1,5 +1,5 @@
 import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
+import { Navbar } from "@/components/navbar/navbar";
 import { Loader2 } from "lucide-react";
 import { Suspense } from "react";
 

--- a/components/navbar/navbar.css
+++ b/components/navbar/navbar.css
@@ -1,0 +1,4 @@
+.cl-profileSectionContent__profile .cl-formButtonPrimary,
+.cl-profileSectionContent__profile .cl-formButtonReset {
+  display: none; /* !!! Remove this if we ever add more than just the avatar to the user settings modal */
+}

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -3,18 +3,20 @@
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { SignInButton, useClerk, useUser } from "@clerk/nextjs";
-import { Logo } from "./Logo";
+import { Logo } from "../Logo";
 import { CircleHelp, Fingerprint, Flame, LogOut, Menu, Settings, Trophy } from "lucide-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useState } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import Link from "next/link";
-import { ProfileMenubar, ProfileMenubarContent, ProfileMenubarItem, ProfileMenubarMenu, ProfileMenubarTrigger } from "./ui/profile-menubar";
+import { ProfileMenubar, ProfileMenubarContent, ProfileMenubarItem, ProfileMenubarMenu, ProfileMenubarTrigger } from "../ui/profile-menubar";
 import { usePathname, useRouter } from "next/navigation";
 import { api } from "@/convex/_generated/api";
 import { useAdminCheck } from "@/hooks/use-admin-check";
-import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "./ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../ui/dialog";
+
+import "./navbar.css";
 
 export const Navbar = () => {
   const [scrolled, setScrolled] = useState(false);


### PR DESCRIPTION
This pull request includes several changes to the import paths for the `Navbar` component across different layout files, as well as some modifications to the `navbar` component itself. The most important changes are summarized below:

### Changes to import paths:

* [`app/(authentication)/layout.tsx`](diffhunk://#diff-1deb75ce6b6c78367f1de1022c7750dd34c2124068bd3b55e075241031324fd9L2-R2): Updated the import path for `Navbar` to `@/components/navbar/navbar`.
* [`app/(developer)/layout.tsx`](diffhunk://#diff-abd703306a6ba1f11c736b320988cd1b12e1ca4a87bce0b6d3e3e749bd23501cL4-R4): Updated the import path for `Navbar` to `@/components/navbar/navbar`.
* [`app/(gameplay)/layout.tsx`](diffhunk://#diff-8da13aadb12a3c3a096af96415ef619975e118200a80c09606565951f3b9a6baL2-R2): Updated the import path for `Navbar` to `@/components/navbar/navbar`.
* [`app/(legal)/layout.tsx`](diffhunk://#diff-47622e1bf31f531148463a2c4ec232d65f13c2e394920f9a1d203b2fe0f25868L2-R2): Updated the import path for `Navbar` to `@/components/navbar/navbar`.
* [`app/(main)/layout.tsx`](diffhunk://#diff-5c551bd531dcf4bccf457ebf353b197db04402c2edde824234e500d2763c74acL2-R2): Updated the import path for `Navbar` to `@/components/navbar/navbar`.
* [`app/(marketing)/layout.tsx`](diffhunk://#diff-dc3a2a05cdd2589d31f3a809f69ff612d44ebda05ee0cfc6aa28dc80e33dd5feL2-R2): Updated the import path for `Navbar` to `@/components/navbar/navbar`.

### Changes to `navbar` component:

* [`components/navbar/navbar.tsx`](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L6-R19): Renamed from `components/navbar.tsx` and updated import paths for several components to use relative paths. Added import for `navbar.css`.
* [`components/navbar/navbar.css`](diffhunk://#diff-94b89bb3b56dce9675f708d28e7bf5846437582ecd196c593c352082b1b3f303R1-R4): Added styles to hide certain buttons in the user settings modal.

Before:
![image](https://github.com/user-attachments/assets/18edc0fd-5502-4b51-a570-f61335e79611)

After:
![image](https://github.com/user-attachments/assets/9dd40dc1-7b0e-44bd-9d30-2feee6667c25)
