### PR TITLE
[fix] image game responsive desktop display switches to mobile to early

### DIFF
--- a/app/(gameplay)/game/_components/ImageGame.tsx
+++ b/app/(gameplay)/game/_components/ImageGame.tsx
@@ -38,7 +38,7 @@ const ImageGame = () => {
           <div className="flex items-center justify-center">
             <p className="text-[1.125rem] text-[#6E7E85]">Select the AI Generated Image</p>
           </div>
-          <div className="flex flex-col xl:flex-row items-center justify-center text-center gap-10 flex-1 px-6 py-10 xl:py-2">
+          <div className="flex flex-col min-[960px]:flex-row items-center justify-center text-center gap-10 flex-1 px-6 py-10 xl:py-2">
             <div className="w-[20rem] h-[20rem] sm:w-[25rem] sm:h-[25rem] rounded-[2.5rem] border-[5px] border-[rgba(110,_126,_133)] overflow-hidden relative select-none sm:hover:scale-105 cursor-pointer transition-transform duration-300" onClick={() => {
               if(isLoading) return;
 


### PR DESCRIPTION
This pull request includes a small change to the `ImageGame` component in the `app/(gameplay)/game/_components/ImageGame.tsx` file. The change modifies the CSS class for a div element to use a media query for responsive design.

* [`app/(gameplay)/game/_components/ImageGame.tsx`](diffhunk://#diff-d264f32dfcd3a43a616e364337fac1c665ae2ef32454c174d3aba5c5eb3dcd55L41-R41): Changed the CSS class from `xl:flex-row` to `min-[960px]:flex-row` to apply the flex direction change at a different breakpoint.

Before:
![image](https://github.com/user-attachments/assets/c1f393c5-53b0-460e-b702-2d980edc30c0)

After:
![image](https://github.com/user-attachments/assets/dd510b0b-fbd3-4178-b741-9acd0401b479)
