### PR TITLE
[added] Noslen on team page + role updates

### DIFF
--- a/app/(main)/about/page.tsx
+++ b/app/(main)/about/page.tsx
@@ -46,17 +46,17 @@ const AboutPage = () => {
           <div className="flex flex-row flex-wrap gap-6 px-4 sm:px-8 md:px-16 max-w-[60rem] justify-center items-center">
             <TeamCard
               name="Dylan Ravel"
-              title="Development"
+              title="Development Lead"
               linkedInURL="https://www.linkedin.com/in/dylanravel/"
             />
             <TeamCard
               name="Divi Newton"
-              title="Design/Curriculum"
+              title="Design Lead"
               linkedInURL="https://www.linkedin.com/in/divinewton/"
             />
             <TeamCard
               name="Noslen Cruz-Muniz"
-              title="Design/Curriculum"
+              title="Curriculum Lead"
             />
           </div>
         </section>

--- a/app/(main)/about/page.tsx
+++ b/app/(main)/about/page.tsx
@@ -57,7 +57,6 @@ const AboutPage = () => {
             <TeamCard
               name="Noslen Cruz-Muniz"
               title="Design/Curriculum"
-              noPfp
             />
           </div>
         </section>


### PR DESCRIPTION
This pull request includes a small change to the `app/(main)/about/page.tsx` file. The change updates the titles of team members to reflect their leadership roles.

* Updated `Dylan Ravel`'s title to "Development Lead" (`app/(main)/about/page.tsx`)
* Updated `Divi Newton`'s title to "Design Lead" (`app/(main)/about/page.tsx`)
* Updated `Noslen Cruz-Muniz`'s title to "Curriculum Lead" and removed the `noPfp` attribute (`app/(main)/about/page.tsx`)

![image](https://github.com/user-attachments/assets/48f68594-0508-4d0b-9b70-7828f0eee88a)
