### PR TITLE
[fix] Require at least one hint when uploading a level

### DIFF
--- a/app/(developer)/admin/_components/_level-upload/level-upload.tsx
+++ b/app/(developer)/admin/_components/_level-upload/level-upload.tsx
@@ -38,12 +38,12 @@ const LevelUpload = () => {
   const createLevelWithImageIds = useMutation(api.levelUpload.createLevelWithImageIds);
 
   useEffect(() => {
-    if (!AIImage || !normalImage || !AIImageName || !normalImageName || !AIPrompt || !AIImageCopyrightCredit || !normalImageCopyrightCredit || !levelGroupName || !levelClassification) {
+    if (!AIImage || !normalImage || !AIImageName || !normalImageName || !AIPrompt || !AIImageCopyrightCredit || !normalImageCopyrightCredit || !levelGroupName || !levelClassification || (!levelHint1 && !levelHint2 && !levelHint3)) {
       setSubmitButtonDisabled(true);
     } else {
       setSubmitButtonDisabled(false);
     }
-  }, [AIPrompt, AIImage, normalImage, AIImageName, normalImageName, AIImageCopyrightCredit, normalImageCopyrightCredit, levelGroupName, levelClassification]);
+  }, [AIPrompt, AIImage, normalImage, AIImageName, normalImageName, AIImageCopyrightCredit, normalImageCopyrightCredit, levelGroupName, levelClassification, levelHint1, levelHint2, levelHint3]);
 
   async function handleImageSubmission() {
     const aiNameInput = document.getElementById("ai-name") as HTMLInputElement;


### PR DESCRIPTION
This pull request includes a change to the `level-upload.tsx` file to enhance the validation logic for the level upload form. The main change is the addition of checks for level hints to ensure that at least one hint is provided before enabling the submit button.

Validation logic enhancement:

* [`app/(developer)/admin/_components/_level-upload/level-upload.tsx`](diffhunk://#diff-aa228d5cbc2858f3a11c6a75f9c89be33ec900709fd5ceb89e92c5f27db09da2L41-R46): Modified the `useEffect` dependency array and the validation condition to include `levelHint1`, `levelHint2`, and `levelHint3`, ensuring that the submit button is only enabled if at least one hint is provided.