### PR TITLE
[added] Streak System

### DIFF
--- a/app/(gameplay)/game/_context/GameContext.tsx
+++ b/app/(gameplay)/game/_context/GameContext.tsx
@@ -42,6 +42,7 @@ export const GameProvider = ({
 
   const clerkUser = useUser();
   const user = useQuery(api.users.getUserByUsername, { username: clerkUser.user?.username ?? "" });
+  const updateStreak = useMutation(api.users.updateStreak);
 
   const [levels, setLevels] = useState<Id<"levels">[]>([]);
   const [currentRound, setCurrentRound] = useState(0);
@@ -140,6 +141,10 @@ export const GameProvider = ({
     const nextRoundNumber = currentRound + 1;
 
     if(nextRoundNumber > levels.length) {      
+      if(user) {
+        updateStreak({ clerkId: user.clerkId });
+      }
+      
       const endOfGameResult = await finishGame({ points: BigInt(score), userID: user?._id ?? undefined });
 
       const query = new URLSearchParams({

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as crons from "../crons.js";
 import type * as game from "../game.js";
 import type * as http from "../http.js";
 import type * as levelUpload from "../levelUpload.js";
@@ -27,6 +28,7 @@ import type * as users from "../users.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
   game: typeof game;
   http: typeof http;
   levelUpload: typeof levelUpload;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,12 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.daily(
+  "Reset inactive streaks",
+  { hourUTC: 8, minuteUTC: 0 }, // 12:00am PST
+  internal.users.resetInactiveStreaks
+);
+
+export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,7 +11,7 @@ export default defineSchema({
     points: v.int64(),
     picture: v.string(),
     currentStreak: v.int64(),
-    lastParticipationDate: v.string(),
+    lastPlayedTimestamp: v.optional(v.number()),
   })
     .index("byClerkId", ["clerkId"])
     .index("byUsername", ["username"])


### PR DESCRIPTION
This pull request introduces several changes to the game context and user management systems, focusing on updating user streaks and handling inactive users. The most important changes include adding a mutation to update user streaks, creating a cron job to reset inactive streaks, and modifying the schema for user data.

### Game Context Changes:

* Added `updateStreak` mutation to the `GameProvider` to update user streaks after each round. [[1]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR45) [[2]](diffhunk://#diff-599aee49dfdc96c778457c7ef11ecf6ee1cfb73f3fa625b49aef22023193398dR144-R147)

### User Management Changes:

* Added a daily cron job to reset inactive user streaks.
* Modified the schema to replace `lastParticipationDate` with `lastPlayedTimestamp` for better timestamp handling.
* Replaced the `internalMutation` for updating streaks with a more detailed `mutation` that handles streak updates based on the last played timestamp.
* Added a new `internalMutation` to reset the streaks of inactive users.


### Reminder:
To test these changes locally, you need to run
```sh
npx convex dev
```
to update your backend instance with the newest code.

Let me know if you get an error, and I can help you. It is because the user schema changed, so you have to do a hack to get it updated.

<img width="129" alt="Screenshot 2025-04-07 at 5 06 42 PM" src="https://github.com/user-attachments/assets/fc89dbe0-856f-4df9-868b-af8ef954369f" />
