### PR TITLE
[added] Streaks on leaderboard entries on /leaderboard

### DIFF
--- a/app/(main)/leaderboard/page.tsx
+++ b/app/(main)/leaderboard/page.tsx
@@ -70,11 +70,11 @@ const LeaderboardPage = () => {
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[1])}</p>
                   <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <PartyPopper className="w-5 h-5 mr-2" />
                       {topUsers.scores[1].toString()}
                     </div>
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
                       {topUsers.streaks[1].toString()}
                     </div>
@@ -90,11 +90,11 @@ const LeaderboardPage = () => {
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[0])}</p>
                   <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <PartyPopper className="w-5 h-5 mr-2" />
                       {topUsers.scores[0].toString()}
                     </div>
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
                       {topUsers.streaks[0].toString()}
                     </div>
@@ -111,11 +111,11 @@ const LeaderboardPage = () => {
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[2])}</p>
                   <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <PartyPopper className="w-5 h-5 mr-2" />
                       {topUsers.scores[2].toString()}
                     </div>
-                    <div className="flex flex-row">
+                    <div className="flex flex-row justify-center items-center">
                       <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
                       {topUsers.streaks[2].toString()}
                     </div>

--- a/app/(main)/leaderboard/page.tsx
+++ b/app/(main)/leaderboard/page.tsx
@@ -3,7 +3,7 @@
 import { FancyBackgroundGradient } from "@/components/fancy-background-gradient";
 import { Footer } from "@/components/footer";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Loader2, Medal, PartyPopper } from "lucide-react";
+import { Flame, Loader2, Medal, PartyPopper } from "lucide-react";
 
 import "./leaderboard.css";
 import { useConvexAuth, useQuery } from "convex/react";
@@ -69,9 +69,15 @@ const LeaderboardPage = () => {
                 </Avatar>
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[1])}</p>
-                  <div className="flex justify-center items-center text-[hsla(342,_30%,_8%,_0.7)] font-bold">
-                    <PartyPopper className="w-5 h-5 mr-2" />
-                    {topUsers.scores[1].toString()}
+                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+                    <div className="flex flex-row">
+                      <PartyPopper className="w-5 h-5 mr-2" />
+                      {topUsers.scores[1].toString()}
+                    </div>
+                    <div className="flex flex-row">
+                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                      {topUsers.streaks[1].toString()}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -83,9 +89,15 @@ const LeaderboardPage = () => {
                 </Avatar>
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[0])}</p>
-                  <div className="flex justify-center items-center text-[hsla(342,_30%,_8%,_0.7)] font-bold">
-                    <PartyPopper className="w-5 h-5 mr-2" />
-                    {topUsers.scores[0].toString()}
+                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+                    <div className="flex flex-row">
+                      <PartyPopper className="w-5 h-5 mr-2" />
+                      {topUsers.scores[0].toString()}
+                    </div>
+                    <div className="flex flex-row">
+                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                      {topUsers.streaks[0].toString()}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -98,9 +110,15 @@ const LeaderboardPage = () => {
                 </Avatar>
                 <div className="mt-[-1.5rem] text-center">
                   <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[2])}</p>
-                  <div className="flex justify-center items-center text-[hsla(342,_30%,_8%,_0.7)] font-bold">
-                    <PartyPopper className="w-5 h-5 mr-2" />
-                    {topUsers.scores[2].toString()}
+                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+                    <div className="flex flex-row">
+                      <PartyPopper className="w-5 h-5 mr-2" />
+                      {topUsers.scores[2].toString()}
+                    </div>
+                    <div className="flex flex-row">
+                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                      {topUsers.streaks[2].toString()}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -122,11 +122,13 @@ export const getLeaderboardEntries = query({
       .take(3);
 
     const scores = topUsers.map((user) => user.points);
+    const streaks = topUsers.map((user) => user.currentStreak);
     const profilePictures = topUsers.map((user) => user.picture);
     const usernames = topUsers.map((user) => user.username);
 
     return {
       scores,
+      streaks,
       profilePictures,
       usernames,
     };


### PR DESCRIPTION
This pull request includes updates to the leaderboard page to display user streaks alongside their scores. The changes involve both the frontend and backend to support this new feature.

Frontend changes:

* [`app/(main)/leaderboard/page.tsx`](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L6-R6): Imported the `Flame` icon from `lucide-react` and added it to the leaderboard display to show user streaks. Updated the layout to accommodate the new streak information. [[1]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L6-R6) [[2]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L72-R81) [[3]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L86-R101) [[4]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L101-R122)

Backend changes:

* [`convex/users.ts`](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R125-R131): Added a new `streaks` field to the leaderboard entries returned by the `getLeaderboardEntries` query, which maps the current streaks of the top users.

![image](https://github.com/user-attachments/assets/ae2a28d9-a1eb-489f-becc-e83980a76538)
