### PR TITLE
[added] Tick effect when streak increases

### DIFF
--- a/components/navbar/navbar.css
+++ b/components/navbar/navbar.css
@@ -2,3 +2,19 @@
 .cl-profileSectionContent__profile .cl-formButtonReset {
   display: none; /* !!! Remove this if we ever add more than just the avatar to the user settings modal */
 }
+
+.streak-tick {
+  display: inline-block;
+  animation: tick-up 0.5s ease-in-out;
+}
+
+@keyframes tick-up {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  50% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -6,7 +6,7 @@ import { SignInButton, useClerk, useUser } from "@clerk/nextjs";
 import { Logo } from "../Logo";
 import { CircleHelp, Fingerprint, Flame, LogOut, Menu, Settings, Trophy } from "lucide-react";
 import { useConvexAuth, useQuery } from "convex/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import Link from "next/link";
@@ -50,6 +50,25 @@ export const Navbar = () => {
     }
   }, [clerkUser]);
 
+  const previousStreakRef = useRef<number | null>(null); // Persist streak across page loads
+  const [isAnimating, setIsAnimating] = useState(false);
+  const hasMounted = useRef(false);
+
+  useEffect(() => {
+    if (user?.currentStreak !== undefined) {
+      if (hasMounted.current) {
+        if (Number(user.currentStreak) !== previousStreakRef.current) {
+          setIsAnimating(true);
+          setTimeout(() => setIsAnimating(false), 500);
+          previousStreakRef.current = Number(user.currentStreak); // Update the ref
+        }
+      } else {
+        hasMounted.current = true;
+        previousStreakRef.current = Number(user.currentStreak); // Set the initial streak
+      }
+    }
+  }, [user?.currentStreak]);
+
   const pathname = usePathname();
 
   const leftPosition = `-${3 + (user?.currentStreak.toString().length || 1) * 0.5}rem`;
@@ -82,7 +101,9 @@ export const Navbar = () => {
                   <ProfileMenubarMenu>
                     <ProfileMenubarTrigger>
                       <div className="absolute right-1 top-1/2 transform -translate-y-1/2 bg-gradient-to-r from-[#B7CECE] to-[#BBBAC6] rounded-[3.125rem] border border-[rgba(110,_126,_133,_0.25)] p-1.5 flex items-center" style={{ left: leftPosition }}>
-                        <p className="mx-1 text-[1.25rem] text-[#1C0F13]">{user?.currentStreak.toString()}</p>
+                        <p className={`mx-1 text-[1.25rem] text-[#1C0F13] ${isAnimating ? "streak-tick" : ""}`}>
+                          {user?.currentStreak.toString()}
+                        </p>
                         <Flame className="h-6 w-6 text-[#1C0F13] fill-[#1C0F13]" />
                       </div>
                       <Avatar className="border-[3.5px] border-[#6E7E85] w-11 h-11 relative top-[1.25px]">


### PR DESCRIPTION
![Screen Recording Apr 7 2025 from ezgif](https://github.com/user-attachments/assets/f540683d-b8c8-48c0-82c4-901cfcbcb058)

This pull request introduces a new animation effect for the user streak count in the navbar component. The key changes include adding CSS for the animation, updating the `navbar.tsx` file to manage the animation state, and ensuring the streak count animates correctly when it changes.

Animation and styling updates:

* [`components/navbar/navbar.css`](diffhunk://#diff-94b89bb3b56dce9675f708d28e7bf5846437582ecd196c593c352082b1b3f303R5-R20): Added a new CSS class `.streak-tick` for the streak animation and defined the `tick-up` keyframes for the animation.

State management for animation:

* [`components/navbar/navbar.tsx`](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L9-R9): Imported `useRef` to manage the previous streak value and added state variables and `useEffect` hooks to handle the animation logic when the streak count changes. [[1]](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L9-R9) [[2]](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784R53-R71) [[3]](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L85-R106)