### PR TITLE
[fix] Streak incrementation bug

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,7 +11,6 @@ export default defineSchema({
     points: v.int64(),
     picture: v.string(),
     currentStreak: v.int64(),
-    lastPlayedTimestamp: v.optional(v.number()),
     lastDailyChallengeCompletion: v.optional(v.number()),
   })
     .index("byClerkId", ["clerkId"])


### PR DESCRIPTION
This pull request includes changes to the `convex/users.ts` and `convex/schema.ts` files to update the handling of user streaks and daily challenge completions. The changes focus on improving the clarity of the code and documentation, as well as updating the schema to reflect these changes.

Schema updates:
* Removed `lastPlayedTimestamp` from the schema and replaced it with `lastDailyChallengeCompletion` to better represent the purpose of the field.

Code documentation and functionality improvements:
* Updated the documentation for the `finishDailyChallenge` mutation to provide clearer descriptions and added missing annotations.
* Refactored the `finishDailyChallenge` mutation to store the current timestamp in a variable before updating the database.
* Updated the `updateStreak` mutation to use `lastDailyChallengeCompletion` instead of `lastPlayedTimestamp`, and improved the documentation for better clarity. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R167-R180) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L188-R197) [[3]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L209-R235)
* Modified the `resetInactiveStreaks` mutation to filter users based on `lastDailyChallengeCompletion` and updated the documentation accordingly.