### PR TITLE
[fix] Streak and Daily challenge not updating correctly

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,6 +11,7 @@ export default defineSchema({
     points: v.int64(),
     picture: v.string(),
     currentStreak: v.int64(),
+    lastPlayTimestamp: v.optional(v.number()),
     lastDailyChallengeCompletion: v.optional(v.number()),
   })
     .index("byClerkId", ["clerkId"])

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -124,8 +124,10 @@ export const finishDailyChallenge = mutation({
     }
 
     const now = new Date().getTime();
+
     await ctx.db.patch(user._id, {
       lastDailyChallengeCompletion: now,
+      lastPlayTimestamp: now,
     });
   },
 });
@@ -192,8 +194,8 @@ export const updateStreak = mutation({
 
     const now = new Date();
     const nowPST = new Date(now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
-    const lastPlay = user.lastDailyChallengeCompletion
-      ? new Date(user.lastDailyChallengeCompletion)
+    const lastPlay = user.lastPlayTimestamp
+      ? new Date(user.lastPlayTimestamp)
       : new Date(0);
     const lastPlayPST = new Date(lastPlay.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
 
@@ -217,7 +219,7 @@ export const updateStreak = mutation({
 
     await ctx.db.patch(user._id, {
       currentStreak: newStreak,
-      lastDailyChallengeCompletion: now.getTime(),
+      lastPlayTimestamp: now.getTime(),
     });
 
     return newStreak;


### PR DESCRIPTION
This pull request introduces changes to the `convex` module to add and utilize a new `lastPlayTimestamp` field in the user schema, which helps in tracking the last time a user played. The most important changes include modifications to the schema definition and updates to the `finishDailyChallenge` and `updateStreak` mutations to use this new field.

Schema updates:

* [`convex/schema.ts`](diffhunk://#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1R14): Added `lastPlayTimestamp` as an optional number field in the user schema.

Mutation updates:

* [`convex/users.ts`](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847R127-R130): Updated the `finishDailyChallenge` mutation to set `lastPlayTimestamp` to the current time when a daily challenge is completed.
* [`convex/users.ts`](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L195-R198): Modified the `updateStreak` mutation to use `lastPlayTimestamp` instead of `lastDailyChallengeCompletion` for determining the last play time. [[1]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L195-R198) [[2]](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L220-R222)