### PR TITLE
[added] Visual indicator for when you are able to increase your streak

### DIFF
--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -17,6 +17,7 @@ import { useAdminCheck } from "@/hooks/use-admin-check";
 import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../ui/dialog";
 
 import "./navbar.css";
+import { canUserIncreaseStreak } from "@/hooks/use-daily-challenge-check";
 
 export const Navbar = () => {
   const [scrolled, setScrolled] = useState(false);
@@ -104,7 +105,11 @@ export const Navbar = () => {
                         <p className={`mx-1 text-[1.25rem] text-[#1C0F13] ${isAnimating ? "streak-tick" : ""}`}>
                           {user?.currentStreak.toString()}
                         </p>
-                        <Flame className="h-6 w-6 text-[#1C0F13] fill-[#1C0F13]" />
+                        <Flame className={
+                          cn(
+                            "h-6 w-6 text-[#1C0F13]",
+                            !canUserIncreaseStreak(user.lastPlayTimestamp) ? "fill-[#1C0F13]" : ""
+                          )} />
                       </div>
                       <Avatar className="border-[3.5px] border-[#6E7E85] w-11 h-11 relative top-[1.25px]">
                         <AvatarImage src={user?.picture} />

--- a/hooks/use-daily-challenge-check.tsx
+++ b/hooks/use-daily-challenge-check.tsx
@@ -27,3 +27,37 @@ export const hasUserPlayedDailyChallengeToday = (userTimestamp: number | undefin
   // Check if the user has already played today
   return nowMidnightPST.getTime() === lastPlayMidnightPST.getTime();
 };
+
+/**
+ * Determines whether a user can increase their streak based on the last time they played
+ * the daily challenge and the current date in the PST timezone.
+ *
+ * @param userTimestamp - The timestamp (in milliseconds) of the user's last daily challenge play.
+ *                        If undefined, the function assumes the user has not played before.
+ * @returns `true` if the user can increase their streak (i.e., they haven't played today and
+ *          it has been no more than 2 days since their last play); otherwise, `false`.
+ */
+export const canUserIncreaseStreak = (userTimestamp: number | undefined) => {
+  if(!userTimestamp) {
+    return true;
+  }
+  
+  if(hasUserPlayedDailyChallengeToday(userTimestamp)) {
+    return false;
+  }
+
+  const now = new Date();
+  const nowPST = new Date(now.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
+  const lastPlay = new Date(userTimestamp);
+  const lastPlayPST = new Date(lastPlay.toLocaleString("en-US", { timeZone: "America/Los_Angeles" }));
+
+  // Reset time part of the dates to midnight PST
+  const nowMidnightPST = new Date(nowPST.getFullYear(), nowPST.getMonth(), nowPST.getDate());
+  const lastPlayMidnightPST = new Date(lastPlayPST.getFullYear(), lastPlayPST.getMonth(), lastPlayPST.getDate());
+
+  // Calculate the difference in days
+  const daysDifference = (nowMidnightPST.getTime() - lastPlayMidnightPST.getTime()) / (24 * 60 * 60 * 1000);
+
+  // Return true if it has been no more than 2 days since the last play
+  return daysDifference > 0 && daysDifference <= 2;
+};


### PR DESCRIPTION
This pull request introduces a new utility function to check if a user can increase their daily challenge streak and integrates this function into the `Navbar` component. The most important changes include adding the new function, modifying the `Navbar` component to use this function, and updating the imports accordingly.

### New Utility Function:

* [`hooks/use-daily-challenge-check.tsx`](diffhunk://#diff-750ccba48a826732caae779f13b97d687f7978385dcce99e831c6373927909c5R30-R63): Added the `canUserIncreaseStreak` function to determine if a user can increase their streak based on the last time they played the daily challenge.

### Integration in Navbar Component:

* [`components/navbar/navbar.tsx`](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784R20): Imported the `canUserIncreaseStreak` function.
* [`components/navbar/navbar.tsx`](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L107-R112): Modified the `Flame` component to conditionally apply a CSS class based on the result of `canUserIncreaseStreak`.

Can Increase Streak:
![image](https://github.com/user-attachments/assets/37011087-8c0e-46a2-bc5a-7dbb53653d97)

Can no longer increase streak:
![image](https://github.com/user-attachments/assets/34255550-ecf9-4de6-a0b9-01e5d700e774)
