### PR TITLE
[dependency] Bump `convex` to `v1.23.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"class-variance-authority": "^0.7.0",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0",
-				"convex": "^1.22.0",
+				"convex": "^1.23.0",
 				"lucide-react": "^0.452.0",
 				"next": "^14.2.26",
 				"next-themes": "^0.3.0",
@@ -3540,14 +3540,14 @@
 			"license": "MIT"
 		},
 		"node_modules/convex": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/convex/-/convex-1.22.0.tgz",
-			"integrity": "sha512-zHDagTUO8SftALBX7MsE90aZ+CpPEV3xkRgmZReN4k3KnM1R6q4qPReY5yUFpKPUwlmSeIXLKtivz4XEaBvj+g==",
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/convex/-/convex-1.23.0.tgz",
+			"integrity": "sha512-Mz2GpCrw3wXR+TWQgUjQPLkZ5ZhnSSJbvZ/+GUdBY4yMwPpoPw5T6DszAFUB2o1SKyhmyes1iYGijueNsZb/Xw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"esbuild": "0.25.1",
 				"jwt-decode": "^4.0.0",
-				"prettier": "3.5.1"
+				"prettier": "3.5.2"
 			},
 			"bin": {
 				"convex": "bin/main.js"
@@ -6545,9 +6545,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-			"integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+			"integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
 			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.0",
-		"convex": "^1.22.0",
+		"convex": "^1.23.0",
 		"lucide-react": "^0.452.0",
 		"next": "^14.2.26",
 		"next-themes": "^0.3.0",


### PR DESCRIPTION
This pull request includes an update to the `package.json` file to upgrade the `convex` package version.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29): Updated the `convex` package from version `1.22.0` to `1.23.0`.