### PR TITLE
[fix] New users unable to access account

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -51,7 +51,7 @@ export const upsertFromClerk = internalMutation({
         points: 0n,
         picture: data.image_url,
         currentStreak: 0n,
-        lastParticipationDate: new Date().toISOString(),
+        lastPlayTimestamp: Date.now(),
       };
             
       await ctx.db.insert("users", userAttributes);


### PR DESCRIPTION
This pull request includes a change to the `convex/users.ts` file to update the timestamp format for user participation.

Timestamp format update:

* [`convex/users.ts`](diffhunk://#diff-26d9bc05df20f463382c8b6b0a926def0dd42b6c84ec6dffcbf721429b090847L54-R54): Modified the `lastParticipationDate` field to use `Date.now()` instead of `new Date().toISOString()` for the `lastPlayTimestamp` field.