### PR TITLE
[added] Mobile leaderboard page

### DIFF
--- a/app/(main)/leaderboard/_components/desktop-leaderboard.tsx
+++ b/app/(main)/leaderboard/_components/desktop-leaderboard.tsx
@@ -1,0 +1,94 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Flame, PartyPopper } from "lucide-react";
+import { LeaderboardProps, truncateUsername } from "./leaderboard-helpers";
+
+const DesktopLeaderboard: React.FC<LeaderboardProps> = ({ topUsers, isAuthenticated, isLoading, user }) => {
+  return ( 
+    <div className="hidden md:flex flex-col items-center gap-y-[1.56rem] pt-20">
+      <div className="flex flex-row gap-x-[1.56rem] items-end">
+        <div className="podium podium-1 w-[12.5rem] h-[12.5rem] rounded-[1.875rem]  border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
+          <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#2</div>
+          <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>
+          <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
+            <AvatarImage src={topUsers.profilePictures[1]} />
+            <AvatarFallback>...</AvatarFallback>
+          </Avatar>
+          <div className="mt-[-1.5rem] text-center">
+            <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncateUsername(topUsers.usernames[1])}</p>
+            <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+              <div className="flex flex-row justify-center items-center">
+                <PartyPopper className="w-5 h-5 mr-2" />
+                {topUsers.scores[1].toString()}
+              </div>
+              <div className="flex flex-row justify-center items-center">
+                <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                {topUsers.streaks[1].toString()}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="podium podium-2 w-[12.5rem] h-[15.63rem] rounded-[1.875rem] border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
+          <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#1</div>
+          <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>               <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
+            <AvatarImage src={topUsers.profilePictures[0]} />
+            <AvatarFallback>...</AvatarFallback>
+          </Avatar>
+          <div className="mt-[-1.5rem] text-center">
+            <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncateUsername(topUsers.usernames[0])}</p>
+            <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+              <div className="flex flex-row justify-center items-center">
+                <PartyPopper className="w-5 h-5 mr-2" />
+                {topUsers.scores[0].toString()}
+              </div>
+              <div className="flex flex-row justify-center items-center">
+                <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                {topUsers.streaks[0].toString()}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="podium podium-3 w-[12.5rem] h-[9.38rem] rounded-[1.875rem]  border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
+          <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#3</div>
+          <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>
+          <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
+            <AvatarImage src={topUsers.profilePictures[2]} />
+            <AvatarFallback>...</AvatarFallback>
+          </Avatar>
+          <div className="mt-[-1.5rem] text-center">
+            <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncateUsername(topUsers.usernames[2])}</p>
+            <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+              <div className="flex flex-row justify-center items-center">
+                <PartyPopper className="w-5 h-5 mr-2" />
+                {topUsers.scores[2].toString()}
+              </div>
+              <div className="flex flex-row justify-center items-center">
+                <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+                {topUsers.streaks[2].toString()}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="podium podium-4 w-full h-[4.38rem] rounded-[1.875rem] flex justify-center items-center border-[3px] border-solid border-[#AFBABD]">
+        {!isAuthenticated && !isLoading && (
+          <p className="font-bold text-[1.5625rem] text-[#6E7E85]">Create an account to save your score!</p>
+        )}
+        {isAuthenticated && !isLoading && user && (
+          <>
+            {topUsers.usernames.includes(user.username) ? (
+              <p className="font-bold text-[1.5625rem] text-[#6E7E85]">
+                You are ranked <span className="font-normal">#{topUsers.usernames.indexOf(user.username) + 1}</span> on the leaderboard!
+              </p>
+            ) : (
+              <p className="font-bold text-[1.5625rem] text-[#6E7E85]">
+                You have <span className="font-normal">{user.points.toString() ?? "0"}</span> points!
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+ 
+export default DesktopLeaderboard;

--- a/app/(main)/leaderboard/_components/leaderboard-helpers.ts
+++ b/app/(main)/leaderboard/_components/leaderboard-helpers.ts
@@ -1,0 +1,46 @@
+import { Doc } from "@/convex/_generated/dataModel";
+
+type UserProfile = Pick<Doc<"users">, "_id" | "picture" | "points" | "clerkId" | "username">;
+
+/**
+ * Represents the properties required for the leaderboard component.
+ * 
+ * @interface LeaderboardProps
+ * 
+ * @property {Object} topUsers - Contains information about the top users on the leaderboard.
+ * @property {bigint[]} topUsers.scores - An array of scores for the top users.
+ * @property {bigint[]} topUsers.streaks - An array of streaks for the top users.
+ * @property {string[]} topUsers.profilePictures - An array of profile picture URLs for the top users.
+ * @property {string[]} topUsers.usernames - An array of usernames for the top users.
+ * 
+ * @property {boolean} isAuthenticated - Indicates whether the current user is authenticated.
+ * @property {boolean} isLoading - Indicates whether the leaderboard data is still loading.
+ * @property {UserProfile | null | undefined} user - The profile of the current user, or null/undefined if not available.
+ */
+export interface LeaderboardProps {
+  topUsers: {
+    scores: bigint[];
+    streaks: bigint[];
+    profilePictures: string[];
+    usernames: string[];
+  }
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  user: UserProfile | null | undefined;
+}
+
+
+/**
+ * Truncates a username to a specified maximum length and appends "..." if the username exceeds that length.
+ *
+ * @param username - The username to be truncated.
+ * @param maxLength - The maximum allowed length for the username. Defaults to 16.
+ * @returns The truncated username if it exceeds the maximum length, otherwise the original username.
+ */
+export function truncateUsername(username: string, maxLength = 16) {
+  if(username.length <= maxLength) {
+    return username;
+  }
+
+  return username.substring(0, maxLength) + "...";
+}

--- a/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
@@ -22,7 +22,8 @@ const MobileLeaderboardPodium: React.FC<MobileLeaderboardPodiumProps> = ({ usern
         </Avatar>
       </div>
       <div className="ml-4 flex flex-col justify-center flex-1">
-        <p className="text-[#6E7E85] font-bold text-start text-[1.25rem]">{truncateUsername(username, 12)}</p>
+        <p className="max-[400px]:hidden block text-[#6E7E85] font-bold text-start text-[1.25rem]">{truncateUsername(username, 60)}</p>
+        <p className="max-[400px]:block hidden text-[#6E7E85] font-bold text-start text-[1.25rem]">{truncateUsername(username, 12)}</p>
         <div className="flex gap-x-4 items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
           <div className="flex flex-row items-center">
             <PartyPopper className="w-5 h-5 mr-2" />

--- a/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
@@ -13,12 +13,14 @@ interface MobileLeaderboardPodiumProps {
 
 const MobileLeaderboardPodium: React.FC<MobileLeaderboardPodiumProps> = ({ username, picture, score, streak, place }) => {
   return (
-    <div className={cn("podium w-full h-[4.38rem] rounded-[1.875rem] border-[5px] border-solid border-[#A5B5B8] flex items-center p-3 gap-x-2", `podium-${place}`)}>
-      <div className="absolute w-[6.25rem] h-[6.25rem] avatar-frame rounded-full"></div>
-      <Avatar className="w-[5.25rem] h-[5.25rem]">
-        <AvatarImage src={picture} />
-        <AvatarFallback>...</AvatarFallback>
-      </Avatar>
+    <div className={cn("podium w-full h-[4.38rem] rounded-[1.875rem] border-[5px] border-solid border-[#A5B5B8] flex items-center p-4 gap-x-1", `podium-${place}`)}>
+      <div className="flex flex-col justify-center items-center">
+        <div className="absolute w-[6.25rem] h-[6.25rem] avatar-frame rounded-full"></div>
+        <Avatar className="w-[5.25rem] h-[5.25rem]">
+          <AvatarImage src={picture} />
+          <AvatarFallback>...</AvatarFallback>
+        </Avatar>
+      </div>
       <div className="ml-4 flex flex-col justify-center flex-1">
         <p className="text-[#6E7E85] font-bold text-start text-[1.25rem]">{truncateUsername(username, 12)}</p>
         <div className="flex gap-x-4 items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">

--- a/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx
@@ -1,0 +1,40 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Flame, PartyPopper } from "lucide-react";
+import { truncateUsername } from "./leaderboard-helpers";
+import { cn } from "@/lib/utils";
+
+interface MobileLeaderboardPodiumProps {
+  username: string;
+  picture: string;
+  score: bigint;
+  streak: bigint;
+  place: number;
+}
+
+const MobileLeaderboardPodium: React.FC<MobileLeaderboardPodiumProps> = ({ username, picture, score, streak, place }) => {
+  return (
+    <div className={cn("podium w-full h-[4.38rem] rounded-[1.875rem] border-[5px] border-solid border-[#A5B5B8] flex items-center p-3 gap-x-2", `podium-${place}`)}>
+      <div className="absolute w-[6.25rem] h-[6.25rem] avatar-frame rounded-full"></div>
+      <Avatar className="w-[5.25rem] h-[5.25rem]">
+        <AvatarImage src={picture} />
+        <AvatarFallback>...</AvatarFallback>
+      </Avatar>
+      <div className="ml-4 flex flex-col justify-center flex-1">
+        <p className="text-[#6E7E85] font-bold text-start text-[1.25rem]">{truncateUsername(username, 12)}</p>
+        <div className="flex gap-x-4 items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
+          <div className="flex flex-row items-center">
+            <PartyPopper className="w-5 h-5 mr-2" />
+            {score.toString()}
+          </div>
+          <div className="flex flex-row items-center">
+            <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
+            {streak.toString()}
+          </div>
+        </div>
+      </div>
+      <div className="text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)]">#{place.toString()}</div>
+    </div>
+  );
+};
+
+export default MobileLeaderboardPodium;

--- a/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
@@ -1,0 +1,54 @@
+import { LeaderboardProps } from "./leaderboard-helpers";
+
+import "../leaderboard.css";
+import MobileLeaderboardPodium from "./mobile-leaderboard-podium";
+
+const MobileLeaderboard: React.FC<LeaderboardProps> = ({ topUsers, isAuthenticated, isLoading, user }) => {
+  return (
+    <>
+      <div className="flex md:hidden flex-col gap-x-[1.56rem] items-end w-full space-y-10">
+        <MobileLeaderboardPodium
+          username={topUsers.usernames[0]}
+          picture={topUsers.profilePictures[0]}
+          score={topUsers.scores[0]}
+          streak={topUsers.streaks[0]}
+          place={1}
+        />
+        <MobileLeaderboardPodium
+          username={topUsers.usernames[1]}
+          picture={topUsers.profilePictures[1]}
+          score={topUsers.scores[1]}
+          streak={topUsers.streaks[1]}
+          place={2}
+        />
+        <MobileLeaderboardPodium
+          username={topUsers.usernames[2]}
+          picture={topUsers.profilePictures[2]}
+          score={topUsers.scores[2]}
+          streak={topUsers.streaks[2]}
+          place={3}
+        />
+      </div>
+      <div className="md:hidden podium podium-4 w-full h-[4.38rem] rounded-[1.875rem] flex justify-center items-center border-[3px] border-solid border-[#AFBABD]">
+        {!isAuthenticated && !isLoading && (
+          <p className="font-bold text-base sm:text-[1.5625rem] text-[#6E7E85]">Create an account to save your score!</p>
+        )}
+        {isAuthenticated && !isLoading && user && (
+          <>
+            {topUsers.usernames.includes(user.username) ? (
+              <p className="font-bold text-base sm:text-[1.5625rem] text-[#6E7E85]">
+                You are ranked <span className="font-normal">#{topUsers.usernames.indexOf(user.username) + 1}</span> on the leaderboard!
+              </p>
+            ) : (
+              <p className="font-bold text-base sm:text-[1.5625rem] text-[#6E7E85]">
+                You have <span className="font-normal">{user.points.toString() ?? "0"}</span> points!
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+ 
+export default MobileLeaderboard;

--- a/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
@@ -6,7 +6,7 @@ import MobileLeaderboardPodium from "./mobile-leaderboard-podium";
 const MobileLeaderboard: React.FC<LeaderboardProps> = ({ topUsers, isAuthenticated, isLoading, user }) => {
   return (
     <>
-      <div className="flex md:hidden flex-col gap-x-[1.56rem] items-end w-full space-y-10">
+      <div className="flex md:hidden flex-col gap-y-[1.56rem] items-end w-full space-y-10">
         <MobileLeaderboardPodium
           username={topUsers.usernames[0]}
           picture={topUsers.profilePictures[0]}

--- a/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
+++ b/app/(main)/leaderboard/_components/mobile-leaderboard.tsx
@@ -6,7 +6,7 @@ import MobileLeaderboardPodium from "./mobile-leaderboard-podium";
 const MobileLeaderboard: React.FC<LeaderboardProps> = ({ topUsers, isAuthenticated, isLoading, user }) => {
   return (
     <>
-      <div className="flex md:hidden flex-col gap-y-[1.56rem] items-end w-full space-y-10">
+      <div className="flex md:hidden flex-col space-y-10 items-end w-full">
         <MobileLeaderboardPodium
           username={topUsers.usernames[0]}
           picture={topUsers.profilePictures[0]}

--- a/app/(main)/leaderboard/page.tsx
+++ b/app/(main)/leaderboard/page.tsx
@@ -2,14 +2,15 @@
 
 import { FancyBackgroundGradient } from "@/components/fancy-background-gradient";
 import { Footer } from "@/components/footer";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Flame, Loader2, Medal, PartyPopper } from "lucide-react";
+import { Loader2, Medal } from "lucide-react";
 
 import "./leaderboard.css";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useEffect, useState } from "react";
 import { useUser } from "@clerk/clerk-react";
+import DesktopLeaderboard from "./_components/desktop-leaderboard";
+import MobileLeaderboard from "./_components/mobile-leaderboard";
 
 const LeaderboardPage = () => {
   const topUsers = useQuery(api.users.getLeaderboardEntries);
@@ -30,14 +31,6 @@ const LeaderboardPage = () => {
     }
   }, [topUsers, user]);
 
-  function truncate(username: string) {
-    if(username.length <= 16) {
-      return username;
-    }
-
-    return username.substring(0, 16) + "...";
-  }
-
   if(!topUsers || areEntriesLoading || isUserLoading || (!isAuthenticated && isLoading)) {
     return (
       <>
@@ -57,92 +50,19 @@ const LeaderboardPage = () => {
       <div className="min-h-full flex flex-col">
         <div className="flex flex-col items-center justify-center text-center gap-y-8 flex-1 px-6 pb-10">
           <Medal className="w-20 h-20 text-[hsla(198,_9%,_48%,_1)]" />
-          <h1 className="text-[2.5rem] font-bold text-[hsla(198,_9%,_48%,_0.75)] pb-20">Leaderboard</h1>
-          <div className="hidden md:flex flex-col items-center gap-y-[1.56rem]">
-            <div className="flex flex-row gap-x-[1.56rem] items-end">
-              <div className="podium podium-1 w-[12.5rem] h-[12.5rem] rounded-[1.875rem]  border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
-                <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#2</div>
-                <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>
-                <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
-                  <AvatarImage src={topUsers.profilePictures[1]} />
-                  <AvatarFallback>...</AvatarFallback>
-                </Avatar>
-                <div className="mt-[-1.5rem] text-center">
-                  <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[1])}</p>
-                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row justify-center items-center">
-                      <PartyPopper className="w-5 h-5 mr-2" />
-                      {topUsers.scores[1].toString()}
-                    </div>
-                    <div className="flex flex-row justify-center items-center">
-                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
-                      {topUsers.streaks[1].toString()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="podium podium-2 w-[12.5rem] h-[15.63rem] rounded-[1.875rem] border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
-                <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#1</div>
-                <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>               <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
-                  <AvatarImage src={topUsers.profilePictures[0]} />
-                  <AvatarFallback>...</AvatarFallback>
-                </Avatar>
-                <div className="mt-[-1.5rem] text-center">
-                  <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[0])}</p>
-                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row justify-center items-center">
-                      <PartyPopper className="w-5 h-5 mr-2" />
-                      {topUsers.scores[0].toString()}
-                    </div>
-                    <div className="flex flex-row justify-center items-center">
-                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
-                      {topUsers.streaks[0].toString()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="podium podium-3 w-[12.5rem] h-[9.38rem] rounded-[1.875rem]  border-[5px] border-solid border-[#A5B5B8] flex flex-col items-center relative">
-                <div className="absolute top-[-1.5rem] text-[2rem] font-bold text-[hsla(246,_16%,_39%,_0.75)] -translate-y-20">#3</div>
-                <div className="absolute w-[6.25rem] h-[6.25rem] -translate-y-1/2 avatar-frame rounded-full"></div>
-                <Avatar className="w-[5.25rem] h-[5.25rem] -translate-y-1/2">
-                  <AvatarImage src={topUsers.profilePictures[2]} />
-                  <AvatarFallback>...</AvatarFallback>
-                </Avatar>
-                <div className="mt-[-1.5rem] text-center">
-                  <p className="text-[#6E7E85] font-bold text-[1.25rem] pb-2">{truncate(topUsers.usernames[2])}</p>
-                  <div className="flex gap-x-4 justify-center items-center text-[hsl(342,_30%,_8%)] opacity-70 font-bold">
-                    <div className="flex flex-row justify-center items-center">
-                      <PartyPopper className="w-5 h-5 mr-2" />
-                      {topUsers.scores[2].toString()}
-                    </div>
-                    <div className="flex flex-row justify-center items-center">
-                      <Flame className="w-5 h-5 mr-2 fill-[hsl(342,_30%,_8%)]" />
-                      {topUsers.streaks[2].toString()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="podium podium-4 w-full h-[4.38rem] rounded-[1.875rem] flex justify-center items-center border-[3px] border-solid border-[#AFBABD]">
-              {!isAuthenticated && !isLoading && (
-                <p className="font-bold text-[1.5625rem] text-[#6E7E85]">Create an account to save your score!</p>
-              )}
-              {isAuthenticated && !isLoading && user && (
-                <>
-                  {topUsers.usernames.includes(user.username) ? (
-                    <p className="font-bold text-[1.5625rem] text-[#6E7E85]">
-                      You are ranked <span className="font-normal">#{topUsers.usernames.indexOf(user.username) + 1}</span> on the leaderboard!
-                    </p>
-                  ) : (
-                    <p className="font-bold text-[1.5625rem] text-[#6E7E85]">
-                      You have <span className="font-normal">{user.points.toString() ?? "0"}</span> points!
-                    </p>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-          <p className="block md:hidden">[ MOBILE VIEW COMING SOON ]</p>
+          <h1 className="text-[2.5rem] font-bold text-[hsla(198,_9%,_48%,_0.75)]">Leaderboard</h1>
+          <DesktopLeaderboard
+            topUsers={topUsers}
+            isAuthenticated={isAuthenticated}
+            isLoading={isLoading}
+            user={user}
+          />
+          <MobileLeaderboard
+            topUsers={topUsers}
+            isAuthenticated={isAuthenticated}
+            isLoading={isLoading}
+            user={user}
+          />
         </div>
         <Footer />
       </div>


### PR DESCRIPTION
This pull request introduces significant updates to the leaderboard component, including the addition of separate desktop and mobile views, and refactoring of existing code for improved modularity and maintainability. The most important changes include the creation of new components for the leaderboard views, the addition of helper functions, and the removal of redundant code.

### New Components:
* [`app/(main)/leaderboard/_components/desktop-leaderboard.tsx`](diffhunk://#diff-85499a9f23aab8267292ad5379a9cade6bb56c614637a101b1aa71c47024b553R1-R94): Added a new `DesktopLeaderboard` component to display the leaderboard for desktop users.
* [`app/(main)/leaderboard/_components/mobile-leaderboard.tsx`](diffhunk://#diff-8fd6df27a9475264da9e3fbdd1f3aea5465e6e8e70468a962523b0bfd99f4620R1-R54): Added a new `MobileLeaderboard` component to display the leaderboard for mobile users.
* [`app/(main)/leaderboard/_components/mobile-leaderboard-podium.tsx`](diffhunk://#diff-5fde40f50f5a8385a9dc2e9aefcfcd91a8b7a3dd08fb3493a52e023f90cf20b5R1-R43): Added a new `MobileLeaderboardPodium` component to display individual user podiums on mobile.

### Helper Functions and Types:
* [`app/(main)/leaderboard/_components/leaderboard-helpers.ts`](diffhunk://#diff-8c0a5a30afe2ec606f51a40709cb7de35d2a71b56d088c1ffcb9884b72f46ad8R1-R46): Added `LeaderboardProps` interface and `truncateUsername` function to handle leaderboard data and username truncation.

### Code Refactoring:
* [`app/(main)/leaderboard/page.tsx`](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L5-R13): Removed inline leaderboard rendering code and replaced it with the new `DesktopLeaderboard` and `MobileLeaderboard` components. Also removed the redundant `truncate` function. [[1]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L5-R13) [[2]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L33-L40) [[3]](diffhunk://#diff-19760ee0d7b0700e4082e46fb0dfb70b8580c7d0070ab9b6b3193838abf94562L60-R65)

![image](https://github.com/user-attachments/assets/65fe878c-b071-45da-abbb-b97f43dfac63)
