### PR TITLE
[fix] Update homepage text

### DIFF
--- a/app/(marketing)/_components/heading.tsx
+++ b/app/(marketing)/_components/heading.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { SignUpButton } from "@clerk/clerk-react";
 import { useConvexAuth } from "convex/react";
-import { CopyCheck, GraduationCap, Save, Share } from "lucide-react";
+import { CopyCheck, GraduationCap, Save, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { CSSProperties } from "react";
 
@@ -37,8 +37,8 @@ export const Heading = () => {
           <p className="pt-2 text-center mr-2 ml-2 font-[400] text-[1.25rem] text-[rgba(28,_15,_19,_0.50)]">Save your progress online</p>
         </div>
         <div className="flex-shrink-0 w-full lg:w-[17.1875rem] h-[10.9375rem] flex flex-col items-center justify-center bg-[linear-gradient(239deg,_rgba(183,_206,_206,_0.85)_0%,_rgba(110,_125,_133,_0.72)_219.48%)] rounded-[3.75rem] lg:translate-y-[-2.9rem] border-[5px] border-solid border-[#A5B5B8] lg:animate-float" style={{ '--initial-translate-y': '-2.9rem', animationDelay: '3s' } as CSSProperties}>
-          <Share className="w-[3.125rem] h-[3.125rem] text-[#6f7c85]" />
-          <p className="pt-2 text-center mr-2 ml-2 font-[400] text-[1.25rem] text-[rgba(28,_15,_19,_0.50)]">Share scores with friends</p>
+          <Users className="w-[3.125rem] h-[3.125rem] text-[#6f7c85]" />
+          <p className="pt-2 text-center mr-2 ml-2 font-[400] text-[1.25rem] text-[rgba(28,_15,_19,_0.50)]">Compare scores with friends</p>
         </div>
         <div className="flex-shrink-0 w-full lg:w-[17.1875rem] h-[10.9375rem] flex flex-col items-center justify-center bg-[linear-gradient(239deg,_rgba(183,_206,_206,_0.85)_0%,_rgba(110,_125,_133,_0.72)_219.48%)] rounded-[3.75rem] lg:translate-y-[10px] border-[5px] border-solid border-[#A5B5B8] lg:animate-float" style={{ '--initial-translate-y': '10px', animationDelay: '0s' } as CSSProperties}>
           <GraduationCap className="w-[3.125rem] h-[3.125rem] text-[#6f7c85]" />

--- a/app/(marketing)/_components/heading.tsx
+++ b/app/(marketing)/_components/heading.tsx
@@ -46,7 +46,7 @@ export const Heading = () => {
         </div>
         <div className="flex-shrink-0 w-full lg:w-[17.1875rem] h-[10.9375rem] flex flex-col items-center justify-center bg-[linear-gradient(239deg,_rgba(183,_206,_206,_0.85)_0%,_rgba(110,_125,_133,_0.72)_219.48%)] rounded-[3.75rem] lg:translate-y-[-2.9rem] border-[5px] border-solid border-[#A5B5B8] lg:animate-float" style={{ '--initial-translate-y': '-2.9rem', animationDelay: '3s' } as CSSProperties}>
           <CopyCheck className="w-[3.125rem] h-[3.125rem] text-[#6f7c85]" />
-          <p className="pt-2 text-center mr-2 ml-2 font-[400] text-[1.25rem] text-[rgba(28,_15,_19,_0.50)]">Practice with Images and Text</p>
+          <p className="pt-2 text-center mr-2 ml-2 font-[400] text-[1.25rem] text-[rgba(28,_15,_19,_0.50)]">Practice with AI images</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request makes updates to the `app/(marketing)/_components/heading.tsx` file to refine the user interface and improve the clarity of the displayed messages. The most important changes include replacing icons and updating the accompanying text.

User Interface Improvements:

* Replaced the `Share` icon with the `Users` icon to better represent the action of comparing scores with friends. Updated the text to "Compare scores with friends" for clarity.
* Modified the text for the `CopyCheck` icon section to specify "Practice with AI images" instead of the more generic "Practice with Images and Text."

Dependency Updates:

* Updated the import statement to replace `Share` with `Users` from the `lucide-react` library.
<img width="1277" alt="Screenshot 2025-04-14 at 11 22 44 AM" src="https://github.com/user-attachments/assets/92352499-2662-4b7a-a5a9-311cb869ab5c" />
