### PR TITLE
[fix] Streak of 0 showed filled in flame when it should be outlined

### DIFF
--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -105,11 +105,14 @@ export const Navbar = () => {
                         <p className={`mx-1 text-[1.25rem] text-[#1C0F13] ${isAnimating ? "streak-tick" : ""}`}>
                           {user?.currentStreak.toString()}
                         </p>
-                        <Flame className={
-                          cn(
+                        <Flame
+                          className={cn(
                             "h-6 w-6 text-[#1C0F13]",
-                            !canUserIncreaseStreak(user.lastPlayTimestamp) ? "fill-[#1C0F13]" : ""
-                          )} />
+                            Number(user?.currentStreak) === 0 || canUserIncreaseStreak(user.lastPlayTimestamp)
+                              ? ""
+                              : "fill-[#1C0F13]"
+                          )}
+                        />
                       </div>
                       <Avatar className="border-[3.5px] border-[#6E7E85] w-11 h-11 relative top-[1.25px]">
                         <AvatarImage src={user?.picture} />


### PR DESCRIPTION
This pull request includes a small update to the `Navbar` component in `components/navbar/navbar.tsx`. The change refactors the `Flame` component's `className` logic to improve readability and correctness.

* [`components/navbar/navbar.tsx`](diffhunk://#diff-6401eaec6ba32926e78bdb4fb50d10a41c75c9efb2a09f294c1eb7fb2617b784L108-R115): Updated the `Flame` component to simplify the conditional logic in its `className` property, ensuring proper handling of the `fill-[#1C0F13]` class based on the user's streak and play timestamp.