### PR TITLE
[removed] Remove beta from navbar

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -19,9 +19,9 @@ export const Logo = ({ clickable, href, showLogoText }: LogoProps) => {
   const logoContent = (
     <div className="flex items-center gap-x-2">
       <Image 
-        src="/logos/Wordmark-beta.svg"
+        src="/logos/Wordmark_Logo.svg"
         height="200"
-        width="252" // TODO: Change back to 200 when out of beta
+        width="200"
         alt="Logo"
         className="dark:hidden"
       />


### PR DESCRIPTION
Once we decide to do this, we can take the website out of beta, and I'll allow users to make accounts.

This pull request includes a minor update to the `Logo` component. The change replaces the logo image file from `Wordmark-beta.svg` to `Wordmark_Logo.svg` and adjusts the width back to `200` as the beta phase is complete.

<img width="1329" alt="Screenshot 2025-04-28 at 10 37 48 AM" src="https://github.com/user-attachments/assets/c103f752-c8d4-451c-8480-387672bb8a2a" />
