### PR TITLE
[improved] Changed "Development Team" to "Software Team"

### DIFF
--- a/app/(main)/about/page.tsx
+++ b/app/(main)/about/page.tsx
@@ -46,30 +46,30 @@ const AboutPage = () => {
           <div className="flex flex-row flex-wrap gap-6 px-4 sm:px-8 md:px-16 max-w-[50rem] justify-center items-center">
             <TeamCard
               name="Dylan Ravel"
-              title="Development Lead"
+              title="Software Team Lead"
               linkedInURL="https://www.linkedin.com/in/dylanravel/"
             />
             <TeamCard
               name="Divi Newton"
-              title="Design Lead"
+              title="Design Team Lead"
               linkedInURL="https://www.linkedin.com/in/divinewton/"
             />
             <TeamCard
               name="Noslen Cruz-Muniz"
-              title="Curriculum Lead"
+              title="Curriculum Team Lead"
             />
             <TeamCard
               name="Cristian Melgoza"
-              title="Development"
+              title="Software Team"
             />
             <TeamCard
               name="Josh McCarthy"
-              title="Curriculum"
+              title="Curriculum Team"
               linkedInURL="https://www.linkedin.com/in/joshua-mccarthy-dev/"
             />
             <TeamCard
               name="Jack Flanagan"
-              title="Curriculum"
+              title="Curriculum Team"
               linkedInURL="https://www.linkedin.com/in/jack-flanagan-571399217/"
             />
           </div>


### PR DESCRIPTION
This pull request updates the titles displayed on the About page to reflect more consistent and team-oriented naming conventions for team members.

Changes to team member titles:

* Updated `Dylan Ravel`'s title from "Development Lead" to "Software Team Lead." (`app/(main)/about/page.tsx`, [app/(main)/about/page.tsxL49-R72](diffhunk://#diff-b6968fe0e1479fb133cb135d3843fb79f1de33bcab3a2c16e01bc38e0ef1f4e8L49-R72))
* Updated `Divi Newton`'s title from "Design Lead" to "Design Team Lead." (`app/(main)/about/page.tsx`, [app/(main)/about/page.tsxL49-R72](diffhunk://#diff-b6968fe0e1479fb133cb135d3843fb79f1de33bcab3a2c16e01bc38e0ef1f4e8L49-R72))
* Updated `Noslen Cruz-Muniz`'s title from "Curriculum Lead" to "Curriculum Team Lead." (`app/(main)/about/page.tsx`, [app/(main)/about/page.tsxL49-R72](diffhunk://#diff-b6968fe0e1479fb133cb135d3843fb79f1de33bcab3a2c16e01bc38e0ef1f4e8L49-R72))
* Changed `Cristian Melgoza`'s title from "Development" to "Software Team." (`app/(main)/about/page.tsx`, [app/(main)/about/page.tsxL49-R72](diffhunk://#diff-b6968fe0e1479fb133cb135d3843fb79f1de33bcab3a2c16e01bc38e0ef1f4e8L49-R72))
* Updated titles for `Josh McCarthy` and `Jack Flanagan` from "Curriculum" to "Curriculum Team." (`app/(main)/about/page.tsx`, [app/(main)/about/page.tsxL49-R72](diffhunk://#diff-b6968fe0e1479fb133cb135d3843fb79f1de33bcab3a2c16e01bc38e0ef1f4e8L49-R72))

![image](https://github.com/user-attachments/assets/516ecba9-a8f3-48e3-ba2b-8924cbb66c85)
