### PR TITLE
[added] Quick Links section on admin dashboard

### DIFF
--- a/app/(developer)/admin/_components/_quick-links/quick-links.tsx
+++ b/app/(developer)/admin/_components/_quick-links/quick-links.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+const QuickLinks = () => {
+  return (
+    <div className="space-y-2">
+      <h2 className="text-3xl">Quick Links</h2>
+      <div className="flex flex-col gap-2">
+        <Link href="https://dashboard.convex.dev/t/dylan-ravel/aidentify/befitting-horse-528" target="_blank">
+          <Button className="w-full">Convex Dashboard</Button>
+        </Link>
+        <Link href="https://dashboard.clerk.com/apps/app_2nSCtE6fj8FQCTOmhPNC1WGrjq1/instances/ins_2uYsfOGnBlvTptlQvJG1Ruj9pVx" target="_blank">
+          <Button className="w-full">Clerk Dashboard</Button>
+        </Link>
+        <Link href="https://github.com/DylanDevelops/aidentify" target="_blank">
+          <Button className="w-full">GitHub Repository</Button>
+        </Link>
+      </div>
+    </div>
+  );
+};
+ 
+export default QuickLinks;

--- a/app/(developer)/admin/page.tsx
+++ b/app/(developer)/admin/page.tsx
@@ -1,6 +1,7 @@
 import { FancyBackgroundGradient } from "@/components/fancy-background-gradient";
 import { Footer } from "@/components/footer";
 import LevelUpload from "./_components/_level-upload/level-upload";
+import QuickLinks from "./_components/_quick-links/quick-links";
 
 const AdminPage = () => {
   return ( 
@@ -10,11 +11,8 @@ const AdminPage = () => {
         <div className="flex flex-col items-start justify-start md:text-justify gap-y-8 md:mt-10 md:mx-40 flex-1 px-6 pb-10">
           <h1 className="text-5xl">Admin Dashboard</h1>
           <div className="space-y-8">
+            <QuickLinks />
             <LevelUpload />
-            <div className="space-y-2">
-              <h2 className="text-3xl">Statistics</h2>
-              <p>[ coming soon ]</p>
-            </div>
           </div>
         </div>
         <Footer />


### PR DESCRIPTION
This pull request introduces a new `QuickLinks` component to the admin dashboard and reorganizes the layout by replacing a placeholder statistics section with this new component. The changes improve navigation by providing quick access to key external resources.

### New `QuickLinks` Component:

* Added a new `QuickLinks` component in `app/(developer)/admin/_components/_quick-links/quick-links.tsx`. This component displays buttons linking to the Convex Dashboard, Clerk Dashboard, and GitHub Repository.

### Integration and Layout Updates:

* Imported the `QuickLinks` component into `app/(developer)/admin/page.tsx` and integrated it into the admin dashboard layout. [[1]](diffhunk://#diff-e844bfac49a2756c9ef0bc6c933ae168098e39e6bfa9a80bc222a7f4fc2288cbR4) [[2]](diffhunk://#diff-e844bfac49a2756c9ef0bc6c933ae168098e39e6bfa9a80bc222a7f4fc2288cbR14-L17)
* Replaced the placeholder "Statistics" section in the admin dashboard with the new `QuickLinks` component, improving the user interface by removing unused elements.

![image](https://github.com/user-attachments/assets/cbb30020-a355-4ec0-b9cf-5a0f68b5f727)